### PR TITLE
Using binding instead of with-redefs

### DIFF
--- a/src/clj_sql_up/migration_files.clj
+++ b/src/clj_sql_up/migration_files.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]))
 
-(def DEFAULT_MIGRATION_DIR "migrations")
+(def ^:dynamic default-migration-dir "migrations")
 
 (defn migration-id [migr-filename]
   (last (re-find #"^([0-9]+)-" migr-filename)))
@@ -12,7 +12,7 @@
 
 ;; TODO: find a way to set migration dir dynamically
 (defn get-migration-files
-  ([] (get-migration-files DEFAULT_MIGRATION_DIR))
+  ([] (get-migration-files default-migration-dir))
   ([dir-name]
    (->> (io/file dir-name)
         (.listFiles)
@@ -21,7 +21,7 @@
         sort)))
 
 (defn load-migration-file
-  ([file] (load-migration-file DEFAULT_MIGRATION_DIR file))
+  ([file] (load-migration-file default-migration-dir file))
   ([dir-name file]
    (load-file (str dir-name "/" file))))
 


### PR DESCRIPTION
Using `binding` is less invasive than `with-redef`.

Cleaned up the test files a bit as well.