### PR TITLE
Allow the caller to change where migrations get created

### DIFF
--- a/src/clj_sql_up/create.clj
+++ b/src/clj_sql_up/create.clj
@@ -1,6 +1,5 @@
-(ns clj-sql-up.create)
-
-(def ^:dynamic *default-migration-dir* "migrations")
+(ns clj-sql-up.create
+  (:require [clj-sql-up.migration-files :refer [*default-migration-dir*]]))
 
 (defn migration-text [path]
   (str ";; " path "\n\n"

--- a/src/clj_sql_up/create.clj
+++ b/src/clj_sql_up/create.clj
@@ -1,5 +1,7 @@
 (ns clj-sql-up.create)
 
+(def ^:dynamic *default-migration-dir* "migrations")
+
 (defn migration-text [path]
   (str ";; " path "\n\n"
        "(defn up []\n"
@@ -10,19 +12,18 @@
 (defn migration-path [name]
   (let [date  (.format (java.text.SimpleDateFormat. "yyyyMMddHHmmssSSS")
                        (java.util.Date.))]
-    (str "migrations/" date "-" name ".clj")))
+    (str *default-migration-dir* "/" date "-" name ".clj")))
 
 (defn create-migration-file [name]
   (let [path (migration-path name)]
     (println (str "Creating file: " path))
-    (spit path (migration-text path))))
+    (spit path (migration-text path))
+    path))
 
 (defn create-migration-dir []
-  (.mkdir (java.io.File. "migrations")))
+  (.mkdir (java.io.File. *default-migration-dir*)))
 
 (defn create [args]
   (create-migration-dir)
   (let [name (first args)]
     (create-migration-file name)))
-
-

--- a/src/clj_sql_up/migration_files.clj
+++ b/src/clj_sql_up/migration_files.clj
@@ -10,7 +10,6 @@
 (defn- migration-file? [filename]
   (re-find #"([0-9]+)-.*\.clj$" filename))
 
-;; TODO: find a way to set migration dir dynamically
 (defn get-migration-files
   ([] (get-migration-files *default-migration-dir*))
   ([dir-name]

--- a/test/clj_sql_up/migration_test.clj
+++ b/test/clj_sql_up/migration_test.clj
@@ -15,6 +15,7 @@
     first
     :c1))
 
+;;from https://gist.github.com/edw/5128978
 (defn- delete-recursively [fname]
   (let [func (fn [func f]
                (when (.isDirectory f)
@@ -27,7 +28,7 @@
   (testing "create"
     (let [dir "test/clj_sql_up/new_migrations"]
       (try
-        (binding [c/*default-migration-dir* dir]
+        (binding [mf/*default-migration-dir* dir]
           (let [path (c/create ["yo"])]
             (.exists (io/as-file path))))
         (finally (delete-recursively dir))))))


### PR DESCRIPTION
I noticed that you allow the caller to dynamically set the location of migration files, but only for migrate/rollback, not for creation. This PR adds that ability.

I kept the same name -- `*default-migration-dir*` -- for the dynamic var, but FWIW, I think it's wrong in both places, and should just be `*migration-dir*`. When we rebind it, we're changing the actual directory; its *value* merely starts out as the default. Or more generally, it's confusing to change something called "default" unless you expect some more granular process to possibly override it.