### PR TITLE
Support for finding migrations in a resources directory

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,8 @@
   :description "A simple leiningen plugin for managing sql migrations"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[cpath-clj "0.1.2"]
+                 [org.clojure/clojure "1.5.1"]
                  [org.clojure/java.jdbc "0.3.3"]
                  [com.cemerick/pomegranate "0.3.0"]]
   :url "https://github.com/ckuttruff/clj-sql-up"

--- a/src/clj_sql_up/migrate.clj
+++ b/src/clj_sql_up/migrate.clj
@@ -29,12 +29,11 @@
      :row-fn #(files/migration-filename
                  (:name %) migration-files))))
 
-
 (defn pending-migrations
   [db]
   (let [migration-files (files/get-migration-files)]
-    (sort (set/difference (set migration-files)
-                          (set (completed-migrations db migration-files))))))
+    (sort-by str (set/difference (set migration-files)
+                                 (set (completed-migrations db migration-files))))))
 
 (defn run-migrations [db files direction]
   (doseq [file files]

--- a/src/clj_sql_up/migration_files.clj
+++ b/src/clj_sql_up/migration_files.clj
@@ -1,32 +1,45 @@
 (ns clj-sql-up.migration-files
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [cpath-clj.core :as cpath]))
 
 (def ^:dynamic *migration-dir* "migrations")
 
-(defn migration-id [migr-filename]
-  (last (re-find #"^([0-9]+)-" migr-filename)))
+(defn last-part [uri]
+  ;;todo: not sure how robust this really is
+  (-> uri str (str/split #"/") last))
 
-(defn- migration-file? [filename]
-  (re-find #"([0-9]+)-.*\.clj$" filename))
+(defn migration-id [uri]
+  (last (re-find #"^([0-9]+)-" (last-part uri))))
+
+(defn- migration-file? [uri]
+  (re-find #"([0-9]+)-.*\.clj$" (last-part uri)))
 
 (defn get-migration-files
   ([] (get-migration-files *migration-dir*))
   ([dir-name]
-   (->> (io/file dir-name)
-        (.listFiles)
-        (map #(.getName %))
-        (filter migration-file?)
-        sort)))
+   (let [dir-file (io/as-file dir-name)]
+     (->>
+        (if (.exists dir-file)
+            (map io/as-url (.listFiles dir-file))
+            (->> (cpath/resources dir-name)
+                 vals
+                 (map first)))
+         (filter #(-> % last-part migration-file?))
+         (sort-by str)))))
 
-(defn load-migration-file
-  ([file] (load-migration-file *migration-dir* file))
-  ([dir-name file]
-   (load-file (str dir-name "/" file))))
+(defn get-migration-file-names
+  ([] (get-migration-file-names *migration-dir*))
+  ([dir-name] (map last-part (get-migration-files dir-name))))
+
+(defn load-migration-file [uri]
+ (->
+   (slurp uri)
+   load-string))
 
 (defn migration-filename [migr-id migr-files]
   "Returns the filename associated with the given migration id"
   [migr-id migr-files]
   (->> migr-files
-       (filter #(re-find (re-pattern (str migr-id ".*")) %))
-       (first)))
+       (filter #(re-find (re-pattern (str migr-id ".*")) (str %)))
+       first))

--- a/test/clj_sql_up/migration_files_test.clj
+++ b/test/clj_sql_up/migration_files_test.clj
@@ -3,7 +3,7 @@
   (:use clojure.test))
 
 (def files
-  (mf/get-migration-files "test/clj_sql_up/migrations"))
+  (mf/get-migration-file-names "test/clj_sql_up/migrations"))
 
 (deftest get-migration-files
   (is (= files ["20130719212020374-zzz.clj" "20130719212023948-ccc.clj"


### PR DESCRIPTION
I need my migrations packaged up as part of an uberjar. This patch provides support for that. I did add a dependency; it's non-trivial to list the resources available in the jar but I found a library that handles that well.