### PR TITLE
Add migration dir config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Add database connection info (both your driver and jdbc connection string):
 
 ```clojure
 :clj-sql-up {:database "jdbc:postgresql://foo@127.0.0.1:5432/foo"
+             :migration-dir "specify/your-migrations-dir" ;;optional, defaults to "migrations"
              :deps [[org.postgresql/postgresql "9.3-1100-jdbc4"]]}
 ;; OR
 :clj-sql-up {:database {:subprotocol "mysql"

--- a/src/leiningen/clj_sql_up.clj
+++ b/src/leiningen/clj_sql_up.clj
@@ -10,6 +10,11 @@
         db-str (if db-env (str "database-" db-env) "database")]
     ((keyword db-str) opts)))
 
+(defn get-migration-dir
+  "fetch migration-dir config option in project.clj options hash"
+  [opts]
+  (or (:migration-dir opts) "migrations"))
+
 (defn clj-sql-up
   "Simply manage sql migrations with clojure/jdbc
 
@@ -20,14 +25,16 @@ rollback n       Rollback last n migrations (n defaults to 1)"
 
   ([project] (println (:doc (meta #'clj-sql-up))))
   ([project command & args]
-     (let [opts (:clj-sql-up project)
-           db   (get-database opts)
-           repos (merge {"central" "http://repo1.maven.org/maven2/"}
-                        {"clojars" "http://clojars.org/repo"}
-                        (:repos opts))]
-       (pome/add-dependencies :coordinates (:deps opts)
-                              :repositories repos)
+   (let [opts (:clj-sql-up project)
+         db   (get-database opts)
+         migration-dir (get-migration-dir opts)
+         repos (merge {"central" "http://repo1.maven.org/maven2/"}
+                      {"clojars" "http://clojars.org/repo"}
+                      (:repos opts))]
+     (pome/add-dependencies :coordinates (:deps opts)
+                            :repositories repos)
+     (binding [clj-sql-up.migration-files/*migration-dir* migration-dir]
        (cond
-        (= command "create")   (create/create args)
-        (= command "migrate")  (migrate/migrate  db)
-        (= command "rollback") (migrate/rollback db (first args))))))
+         (= command "create")   (create/create args)
+         (= command "migrate")  (migrate/migrate db)
+         (= command "rollback") (migrate/rollback db (first args)))))))

--- a/test/clj_sql_up/migration_test.clj
+++ b/test/clj_sql_up/migration_test.clj
@@ -97,8 +97,7 @@
         (is (= 0 (count-records db-spec "aaa")))
         (is (= 0 (count-records db-spec "bbb")))
         (is (= 0 (count-records db-spec "ccc")))
-        (is (= 0 (count-records db-spec "zzz")))))
-    ))
+        (is (= 0 (count-records db-spec "zzz")))))))
 
 
 (deftest test-classpath-migrate-and-rollback


### PR DESCRIPTION
In regards to Issue #15 (Adding config option to options hash for lein plugin)

Granted this does not add the ability to use the lein plugin AND utilize migrations on the classpath, but I soon realized after posting the issue that I do not need them on the class path, but it is still preferential for me to specify another migration dir while utilizing the lein plugin.

Also, I am practically brand spanking new to Clojure, so please forgive me if I am not doing something properly.